### PR TITLE
Better error handling for prompt line

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -37,11 +37,12 @@ input_field = TextArea(
     style="class:input-field",
     multiline=False,
     wrap_lines=False,
+    dont_extend_height=True,
 )
 
-todo_field = TextArea(style="class:output-field")
-inprogress_field = TextArea(style="class:output-field")
-completed_field = TextArea(style="class:output-field")
+todo_field = TextArea(focusable=False, style="class:output-field")
+inprogress_field = TextArea(focusable=False, style="class:output-field")
+completed_field = TextArea(focusable=False, style="class:output-field")
 
 categories = [
     Window(
@@ -80,7 +81,7 @@ def accept(buff):
         elif input_field.text[:2] == "mc":
             moveToCompleted(input_field.text[3])
     except BaseException as e:
-        print("\nError", e)
+        return
 
 
 input_field.accept_handler = accept
@@ -172,6 +173,7 @@ body = HSplit(
     ]
 )
 
+
 # 2. Key bindings
 kb = KeyBindings()
 
@@ -184,10 +186,7 @@ def _(event):
 
 # 3. The `Application`
 application = Application(
-    layout=Layout(body, focused_element=input_field),
-    key_bindings=kb,
-    mouse_support=True,
-    full_screen=True,
+    layout=Layout(body), key_bindings=kb, mouse_support=True, full_screen=True,
 )
 
 


### PR DESCRIPTION
## Overview
When a user gives unexpected inputs on prompt line, the application becomes out of order.
Specifically, the prompt line becomes no longer a one-line prompt, and the first top line of the application becomes truncated. 

## TODO:
- [x] Make sure that prompt line is always one line even when there is a wrong input.
  - [x] Input validation for input field for prompt
- :no_entry_sign:  Add `FloatContainer` to show the error message more easily to the user.
  - Nice to have: Will come back to nice-to-have feature once basic functionality of the app becomes stabilized.

![prompt_error](https://user-images.githubusercontent.com/13269872/73601329-ac9c7100-452d-11ea-9033-f1f66079cdc8.png)
